### PR TITLE
Fix build and add ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: Continuous integration
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+  DEBIAN_FRONTEND: noninteractive
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: install toolchain
+        run: rustup toolchain install nightly --component rustfmt
+      - name: fmt
+        run: cargo +nightly fmt --all --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libxkbcommon-dev
+      - name: install toolchain
+        run: rustup show
+      - uses: Swatinem/rust-cache@v2
+      - name: clippy
+        run: cargo clippy --all-features --all-targets -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libxkbcommon-dev
+      - name: install toolchain
+        run: rustup show
+      - uses: Swatinem/rust-cache@v2
+      - name: test
+        run: cargo test --all-features

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,10 @@
-use std::{env, fs, path::PathBuf};
+use std::path::PathBuf;
+use std::{env, fs};
 use xdgen::{App, Context, FluentString};
 
 fn main() {
-    let id = env::var("APP_ID").unwrap();
+    println!("cargo:rerun-if-env-changed=APP_ID");
+    let id = env::var("APP_ID").unwrap_or_else(|_| String::from("com.system76.CosmicAppLibrary"));
     let ctx = Context::new("i18n", env::var("CARGO_PKG_NAME").unwrap()).unwrap();
     let app = App::new(FluentString("xdg-title"))
         .comment(FluentString("xdg-comment"))

--- a/cargo.just
+++ b/cargo.just
@@ -13,7 +13,8 @@ build-release *args: (build-debug '--release' args)
 
 # Compile with a vendored tarball
 [no-cd]
-build-vendored *args: vendor-extract (build-release '--frozen --offline' args)
+build-vendored *args: vendor-extract
+    LOCKSTEP_XML_PATH="${PWD}/vendor/atspi-common/xml" cargo build --release --frozen --offline {{args}}
 
 # Check for errors and linter warnings
 [no-cd]

--- a/justfile
+++ b/justfile
@@ -2,7 +2,6 @@ name := 'cosmic-app-library'
 appid := 'com.system76.CosmicAppLibrary'
 
 export APP_ID := 'com.system76.CosmicAppLibrary'
-export LOCKSTEP_XML_PATH := absolute_path('vendor/atspi-common/xml')
 
 rootdir := ''
 prefix := '/usr'

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,8 +15,8 @@ use cosmic::iced::runtime::{Action, platform_specific, task};
 use cosmic::iced::window;
 use cosmic::surface::action::{LiveSettings, app_layer_shell, simple_layer_shell, simple_popup};
 use cosmic::widget::menu::menu_column::MenuColumn;
+use cosmic::widget::reorderable_flex_row;
 use cosmic::widget::space::horizontal;
-use cosmic::widget::{ListColumn, reorderable_flex_row};
 use cosmic::{
     Element,
     app::{Core, CosmicFlags, Settings, Task},
@@ -77,7 +77,7 @@ use cosmic::{
     keyboard_nav,
     theme::{self, Button, TextInput},
     widget::{
-        self, Column,
+        self,
         autosize::autosize,
         button::{self, Catalog as ButtonStyleSheet},
         divider,
@@ -833,19 +833,17 @@ impl cosmic::Application for CosmicAppLibrary {
             }
             Message::Layer(e, id) => {
                 match e {
-                    LayerEvent::Focused => {
-                        if self.menu.is_none() {
-                            if id == SurfaceId::RESERVED {
-                                return text_input::focus(SEARCH_ID.clone()).chain(
-                                    iced_runtime::task::widget(find_focused()).map(|id| {
-                                        cosmic::Action::App(Message::UpdateFocused(Some(id)))
-                                    }),
-                                );
-                            } else if id == *DELETE_GROUP_WINDOW_ID {
-                                return button::focus(SUBMIT_DELETE_ID.clone());
-                            } else if id == *NEW_GROUP_WINDOW_ID {
-                                return text_input::focus(NEW_GROUP_ID.clone());
-                            }
+                    LayerEvent::Focused if self.menu.is_none() => {
+                        if id == SurfaceId::RESERVED {
+                            return text_input::focus(SEARCH_ID.clone()).chain(
+                                iced_runtime::task::widget(find_focused()).map(|id| {
+                                    cosmic::Action::App(Message::UpdateFocused(Some(id)))
+                                }),
+                            );
+                        } else if id == *DELETE_GROUP_WINDOW_ID {
+                            return button::focus(SUBMIT_DELETE_ID.clone());
+                        } else if id == *NEW_GROUP_WINDOW_ID {
+                            return text_input::focus(NEW_GROUP_ID.clone());
                         }
                     }
                     LayerEvent::Unfocused => {
@@ -1044,7 +1042,7 @@ impl cosmic::Application for CosmicAppLibrary {
                     self.menu = Some(i);
                     let offset = self.scroll_offset as i32;
                     return cosmic::surface::surface_task(simple_popup(
-                        || LiveSettings::default(),
+                        LiveSettings::default,
                         move || {
                             SctkPopupSettings {
                         parent: SurfaceId::RESERVED,

--- a/src/widgets/application.rs
+++ b/src/widgets/application.rs
@@ -316,12 +316,12 @@ where
                     state.right_press = true;
                     shell.capture_event();
                 }
-                Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Right)) => {
-                    if state.right_press {
-                        shell.publish(self.on_right_release.as_ref()(layout.bounds()));
-                        state.right_press = false;
-                        shell.capture_event();
-                    }
+                Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Right))
+                    if state.right_press =>
+                {
+                    shell.publish(self.on_right_release.as_ref()(layout.bounds()));
+                    state.right_press = false;
+                    shell.capture_event();
                 }
                 _ => {}
             }


### PR DESCRIPTION
The changes in https://github.com/pop-os/cosmic-app-library/pull/399 broke `just build-release`.

Moving the variable to `build-vendored` fixes the original issue, and doesn't cause regression.

Also added a default APP ID so `cargo clippy` doesn't fail because of no APP_ID env var.

Also not sure why ci.yml was [dropped](https://github.com/pop-os/cosmic-app-library/pull/399/changes/0cde311fb2d5de7f26a473cca29308a254357ca0#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL1). But I added it back + clippy and test.
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

