### PR TITLE
fix: retain the default discrete GPU

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -331,6 +331,29 @@ async fn try_get_gpus() -> Option<Vec<Gpu>> {
     Some(gpus)
 }
 
+fn preferred_gpu_idx(gpus: &[Gpu], prefers_discrete: bool) -> Option<usize> {
+    if prefers_discrete {
+        gpus.iter()
+            .position(|gpu| gpu.default && gpu.discrete)
+            .or_else(|| gpus.iter().position(|gpu| gpu.discrete))
+            .or_else(|| gpus.iter().position(|gpu| !gpu.default))
+    } else {
+        gpus.iter().position(|gpu| gpu.default)
+    }
+}
+
+fn automatic_gpu_idx(gpus: &[Gpu], prefers_discrete: bool) -> Option<usize> {
+    if !prefers_discrete || gpus.iter().any(|gpu| gpu.default && gpu.discrete) {
+        None
+    } else {
+        preferred_gpu_idx(gpus, true)
+    }
+}
+
+fn automatic_gpu_idx_from_available(gpus: Option<&[Gpu]>, prefers_discrete: bool) -> Option<usize> {
+    gpus.and_then(|gpus| automatic_gpu_idx(gpus, prefers_discrete))
+}
+
 impl CosmicAppLibrary {
     fn create_dummy_layer_surface(&mut self) -> Task<Message> {
         self.needs_clear = true;
@@ -883,7 +906,9 @@ impl cosmic::Application for CosmicAppLibrary {
                         .and_then(|focus| self.entry_ids.iter().position(|id| focus == id))
                         .unwrap_or_default()
                 };
-                let gpu_idx = None;
+                let gpu_idx = self.entry_path_input.get(i).and_then(|entry| {
+                    automatic_gpu_idx_from_available(self.gpus.as_deref(), entry.prefers_dgpu)
+                });
                 return self.activate_app(i, gpu_idx);
             }
             Message::ActivationToken(token, app_id, exec, gpu_idx, terminal) => {
@@ -1090,6 +1115,10 @@ impl cosmic::Application for CosmicAppLibrary {
                             tasks.push(self.filter_apps());
                         }
                         MenuAction::DesktopAction(exec) => {
+                            let gpu_idx = automatic_gpu_idx_from_available(
+                                self.gpus.as_deref(),
+                                info.prefers_dgpu,
+                            );
                             let mut exec = shlex::Shlex::new(&exec);
 
                             let mut cmd = match exec.next() {
@@ -1103,6 +1132,11 @@ impl cosmic::Application for CosmicAppLibrary {
                                 if !arg.starts_with('%') {
                                     cmd.arg(arg);
                                 }
+                            }
+                            if let Some(gpu) =
+                                gpu_idx.and_then(|gpu_idx| self.gpus.as_deref()?.get(gpu_idx))
+                            {
+                                cmd.envs(&gpu.environment);
                             }
                             let _ = cmd.spawn();
                             return self.hide();
@@ -1321,11 +1355,7 @@ impl cosmic::Application for CosmicAppLibrary {
 
             if let Some(gpus) = self.gpus.as_ref() {
                 for (j, gpu) in gpus.iter().enumerate() {
-                    let default_idx = if menu.prefers_dgpu {
-                        gpus.iter().position(|gpu| !gpu.default).unwrap_or(0)
-                    } else {
-                        gpus.iter().position(|gpu| gpu.default).unwrap_or(0)
-                    };
+                    let default_idx = preferred_gpu_idx(gpus, menu.prefers_dgpu).unwrap_or(0);
                     list_column.push(
                         menu_button(text::body(format!(
                             "{} {}",
@@ -1554,13 +1584,8 @@ impl cosmic::Application for CosmicAppLibrary {
             .zip(self.entry_icon_handles.iter())
             .enumerate()
             .map(|(i, ((entry, id), icon_handle))| {
-                let gpu_idx = self.gpus.as_ref().map(|gpus| {
-                    if entry.prefers_dgpu {
-                        gpus.iter().position(|gpu| !gpu.default).unwrap_or(0)
-                    } else {
-                        gpus.iter().position(|gpu| gpu.default).unwrap_or(0)
-                    }
-                });
+                let gpu_idx =
+                    automatic_gpu_idx_from_available(self.gpus.as_deref(), entry.prefers_dgpu);
                 let dup = entry
                     .path
                     .as_ref()


### PR DESCRIPTION
I tried to play the game "Lethal Company" but it just renders as a plain black fullscreen window when launched through steam. I noticed that the game was not using my discrete NVIDIA GPU, but instead my integrated AMD iGPU. After some debugging I noticed that steam itself sets `PrefersNonDefaultGPU=true` in `/usr/share/applications/steam.desktop`, which on my machine caused the existing GPU selection policy to select the AMD iGPU:
- NVIDIA RTX 3090: `Default=true`, `Discrete=true`
- AMD iGPU: `Default=false`, `Discrete=false`

I changed the GPU selection policy like the following which now allows Lethal Company to render like intended on my discrete NVIDIA GPU when Steam was launched through the app library which this patch applied. This is the policy is settled on:

1. Applications without `PrefersNonDefaultGPU=true` receive no GPU override
2. If an application requests discrete GPU and the default GPU is discrete, emit no override since the default already satisfies that
3. Otherwise select the first GPU marked `discrete=true`
4. If no GPU is marked discrete, fall back to a non-default GPU for compatibility with legacy behavior
5. If GPU discovery fails or produces no selectable GPU, emit no override and allow the application to launch
6. When several GPUs are marked discrete, prefer one that is also marked default before selecting another discrete GPU

If this pull requests gets merged, I happily adapt this to cosmic-launcher, launcher, cosmic-applets and cosmic-store. Once it is properly solved in all those places, closing the issues https://github.com/pop-os/cosmic-epoch/issues/2831 and https://github.com/pop-os/cosmic-epoch/issues/3059 should be possible.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

